### PR TITLE
Parse watchs and cscript BDB records

### DIFF
--- a/src/KEYS.md
+++ b/src/KEYS.md
@@ -46,13 +46,13 @@
 
 - [ ] ckey
 - [ ] csapzkey
-- [ ] cscript
+- [x] cscript
 - [ ] czkey
 - [ ] destdata
 - [ ] hdseed
 - [ ] sapextfvk
 - [ ] vkey
-- [ ] watchs
+- [x] watchs
 - [ ] wkey
 
 ## Removed

--- a/src/migrate/addresses.rs
+++ b/src/migrate/addresses.rs
@@ -1,16 +1,22 @@
 use anyhow::{Result, anyhow};
+use std::collections::{HashMap, HashSet};
 use zcash_keys::keys::UnifiedAddressRequest;
 use zip32::DiversifierIndex;
 
-use std::collections::HashMap;
-
-use zewif::{Account, ProtocolAddress, UnifiedAddress, sapling::SaplingExtendedSpendingKey};
+use zewif::{
+    Account, DerivationInfo, NonHardenedChildIndex, ProtocolAddress, UnifiedAddress,
+    sapling::SaplingExtendedSpendingKey,
+    transparent::{TransparentSpendAuthority, TransparentSpendingKey},
+};
 
 use super::keys::find_sapling_key_for_ivk;
 use crate::{
     ZcashdWallet,
     migrate::{AddressId, AddressRegistry},
-    zcashd_wallet::{Address, ReceiverType, UfvkFingerprint},
+    zcashd_wallet::{
+        Address, ReceiverType, UfvkFingerprint,
+        transparent::{KeyPair, WatchScriptKind},
+    },
 };
 
 /// Convert ZCashd transparent addresses to Zewif format
@@ -26,45 +32,155 @@ pub fn convert_transparent_addresses(
 ) -> Result<()> {
     // Flag for multi-account mode
     let multi_account_mode = address_registry.is_some() && accounts_map.is_some();
+    let network = wallet.network();
+    let mut emitted: HashSet<String> = HashSet::new();
 
-    // Process address_names which contain transparent addresses
-    for (zcashd_address, name) in wallet.address_names() {
-        // Create address components
-        let transparent_address = zewif::transparent::Address::new(zcashd_address.clone());
-        let protocol_address = ProtocolAddress::Transparent(transparent_address);
-        let mut zewif_address = zewif::Address::new(protocol_address);
-        zewif_address.set_name(name.clone());
-
-        // Set purpose if available
-        if let Some(purpose) = wallet.address_purposes().get(zcashd_address) {
-            zewif_address.set_purpose(purpose.clone());
+    // Process address_names which contain transparent addresses. These have
+    // no associated spend material on their own; spend authority and
+    // derivation info, when available, are attached by the keypair pass below.
+    for zcashd_address in wallet.address_names().keys() {
+        let addr_str: String = zcashd_address.clone().into();
+        if !emitted.insert(addr_str.clone()) {
+            continue;
         }
 
-        // In multi-account mode, try to assign to the correct account
-        let mut assigned = false;
+        emit_transparent_address(
+            wallet,
+            default_account,
+            address_registry,
+            accounts_map,
+            multi_account_mode,
+            addr_str,
+            None,
+            None,
+        );
+    }
 
-        if multi_account_mode {
-            let registry = address_registry.unwrap();
-            let addr_id = AddressId::Transparent(zcashd_address.clone().into());
-
-            if let Some(account_id) = registry.find_account(&addr_id) {
-                if let Some(accounts) = accounts_map.as_mut() {
-                    if let Some(target_account) = accounts.get_mut(account_id) {
-                        // Add to the specified account
-                        target_account.add_address(zewif_address.clone());
-                        assigned = true;
-                    }
-                }
-            }
+    // Imported transparent keypairs (HD-derived or standalone).
+    for keypair in wallet.keys().keypairs() {
+        let addr_str = keypair.pubkey().key_id().to_string(network);
+        if !emitted.insert(addr_str.clone()) {
+            continue;
         }
 
-        // If not assigned to an account or in single-account mode, add to default account
-        if !assigned {
-            default_account.add_address(zewif_address);
+        let (spend_authority, derivation_info) = spend_info_for_keypair(keypair);
+        emit_transparent_address(
+            wallet,
+            default_account,
+            address_registry,
+            accounts_map,
+            multi_account_mode,
+            addr_str,
+            spend_authority,
+            derivation_info,
+        );
+    }
+
+    // Watch-only scripts (P2PKH/P2SH).
+    for watch_script in wallet.watch_scripts() {
+        let addr_str = match watch_script.kind() {
+            WatchScriptKind::P2PKH(key_id) => key_id.to_string(network),
+            WatchScriptKind::P2SH(script_id) => script_id.to_string(network),
+            WatchScriptKind::P2PK(_) | WatchScriptKind::Other => continue,
+        };
+        if !emitted.insert(addr_str.clone()) {
+            continue;
         }
+
+        emit_transparent_address(
+            wallet,
+            default_account,
+            address_registry,
+            accounts_map,
+            multi_account_mode,
+            addr_str,
+            None,
+            None,
+        );
     }
 
     Ok(())
+}
+
+fn spend_info_for_keypair(
+    keypair: &KeyPair,
+) -> (Option<TransparentSpendAuthority>, Option<DerivationInfo>) {
+    if let Some(hd_path) = keypair.metadata().hd_keypath() {
+        let derivation_info = derivation_info_from_keypath(hd_path);
+        // Even if we couldn't parse the keypath, the key is HD-derived in
+        // origin — record `Derived` so consumers know the spending key is
+        // recoverable from the seed rather than missing.
+        (Some(TransparentSpendAuthority::Derived), derivation_info)
+    } else {
+        match keypair.privkey().secp256k1_scalar() {
+            Ok(scalar) => (
+                Some(TransparentSpendAuthority::SpendingKey(
+                    TransparentSpendingKey::new(scalar),
+                )),
+                None,
+            ),
+            Err(_) => (None, None),
+        }
+    }
+}
+
+fn derivation_info_from_keypath(keypath: &str) -> Option<DerivationInfo> {
+    // Expected non-hardened tail: `.../<change>/<address_index>`.
+    let mut parts = keypath.rsplit('/');
+    let address_index = parts.next()?.parse::<u32>().ok()?;
+    let change = parts.next()?.parse::<u32>().ok()?;
+    Some(DerivationInfo::new(
+        NonHardenedChildIndex::from(change),
+        NonHardenedChildIndex::from(address_index),
+    ))
+}
+
+fn emit_transparent_address(
+    wallet: &ZcashdWallet,
+    default_account: &mut zewif::Account,
+    address_registry: Option<&AddressRegistry>,
+    accounts_map: &mut Option<&mut HashMap<UfvkFingerprint, Account>>,
+    multi_account_mode: bool,
+    addr_str: String,
+    spend_authority: Option<TransparentSpendAuthority>,
+    derivation_info: Option<DerivationInfo>,
+) {
+    let zcashd_address = Address::from(addr_str.clone());
+
+    let mut transparent_address = zewif::transparent::Address::new(addr_str);
+    if let Some(authority) = spend_authority {
+        transparent_address.set_spend_authority(authority);
+    }
+    if let Some(info) = derivation_info {
+        transparent_address.set_derivation_info(info);
+    }
+
+    let mut zewif_address = zewif::Address::new(ProtocolAddress::Transparent(transparent_address));
+
+    if let Some(name) = wallet.address_names().get(&zcashd_address) {
+        zewif_address.set_name(name.clone());
+    }
+    if let Some(purpose) = wallet.address_purposes().get(&zcashd_address) {
+        zewif_address.set_purpose(purpose.clone());
+    }
+
+    let mut assigned = false;
+    if multi_account_mode {
+        let registry = address_registry.unwrap();
+        let addr_id = AddressId::Transparent(zcashd_address.into());
+        if let Some(account_id) = registry.find_account(&addr_id) {
+            if let Some(accounts) = accounts_map.as_mut() {
+                if let Some(target_account) = accounts.get_mut(account_id) {
+                    target_account.add_address(zewif_address.clone());
+                    assigned = true;
+                }
+            }
+        }
+    }
+
+    if !assigned {
+        default_account.add_address(zewif_address);
+    }
 }
 
 /// Convert ZCashd sapling addresses to Zewif format

--- a/src/zcashd_parser.rs
+++ b/src/zcashd_parser.rs
@@ -20,10 +20,14 @@ use crate::{
         orchard::OrchardNoteCommitmentTree,
         sapling::{SaplingKey, SaplingKeys, SaplingZPaymentAddress},
         sprout::{SproutKeys, SproutPaymentAddress, SproutSpendingKey},
-        transparent::{KeyPair, KeyPoolEntry, Keys, PrivKey, PubKey, WalletKey, WalletKeys},
+        transparent::{
+            KeyPair, KeyPoolEntry, Keys, PrivKey, PubKey, ScriptId, WalletKey, WalletKeys,
+            WatchScript,
+        },
         u252,
     },
 };
+use zewif::Script;
 
 #[derive(Debug)]
 pub struct ZcashdParser<'a> {
@@ -76,6 +80,7 @@ impl<'a> ZcashdParser<'a> {
         // csapzkey
 
         // cscript
+        let cscripts = self.parse_cscripts()?;
 
         // czkey
 
@@ -127,6 +132,7 @@ impl<'a> ZcashdParser<'a> {
         // vkey
 
         // watchs
+        let watch_scripts = self.parse_watch_scripts()?;
 
         // **witnesscachesize**
         let witnesscachesize = self.parse_i64("witnesscachesize")?;
@@ -179,6 +185,7 @@ impl<'a> ZcashdParser<'a> {
             bestblock_nomerkle,
             bestblock,
             client_version,
+            cscripts,
             default_key,
             key_pool,
             keys,
@@ -196,6 +203,7 @@ impl<'a> ZcashdParser<'a> {
             wallet_keys,
             transactions,
             unified_accounts,
+            watch_scripts,
             witnesscachesize,
         );
 
@@ -603,6 +611,48 @@ impl<'a> ZcashdParser<'a> {
             self.mark_key_parsed(&key);
         }
         Ok(key_pool)
+    }
+
+    fn parse_cscripts(&self) -> Result<HashMap<ScriptId, Script>> {
+        let mut cscripts = HashMap::new();
+        if !self.dump.has_keys_for_keyname("cscript") {
+            return Ok(cscripts);
+        }
+        let records = self
+            .dump
+            .records_for_keyname("cscript")
+            .context("Getting 'cscript' records")?;
+        for (key, value) in records {
+            let script_id = parse!(buf = &key.data, ScriptId, "cscript ScriptID")?;
+            let script = parse!(buf = value.as_data(), Script, "cscript redeem script")?;
+            if cscripts.contains_key(&script_id) {
+                bail!("Duplicate cscript ScriptID found: {:?}", script_id);
+            }
+            cscripts.insert(script_id, script);
+
+            self.mark_key_parsed(&key);
+        }
+        Ok(cscripts)
+    }
+
+    fn parse_watch_scripts(&self) -> Result<Vec<WatchScript>> {
+        let mut watch_scripts = Vec::new();
+        if !self.dump.has_keys_for_keyname("watchs") {
+            return Ok(watch_scripts);
+        }
+        let records = self
+            .dump
+            .records_for_keyname("watchs")
+            .context("Getting 'watchs' records")?;
+        for (key, _value) in records {
+            let watch_script = parse!(buf = &key.data, WatchScript, "watch-only script")?;
+            if watch_scripts.contains(&watch_script) {
+                bail!("Duplicate watchs script found: {:?}", watch_script);
+            }
+            watch_scripts.push(watch_script);
+            self.mark_key_parsed(&key);
+        }
+        Ok(watch_scripts)
     }
 
     fn parse_transactions(&self, strict: bool) -> Result<HashMap<TxId, WalletTx>> {

--- a/src/zcashd_wallet.rs
+++ b/src/zcashd_wallet.rs
@@ -28,12 +28,12 @@ pub mod sprout;
 pub mod transparent;
 
 use std::collections::HashMap;
-use zewif::{Bip39Mnemonic, Network, TxId, sapling::SaplingIncomingViewingKey};
+use zewif::{Bip39Mnemonic, Network, Script, TxId, sapling::SaplingIncomingViewingKey};
 
 use orchard::OrchardNoteCommitmentTree;
 use sapling::{SaplingKeys, SaplingZPaymentAddress};
 use sprout::SproutKeys;
-use transparent::{KeyPoolEntry, Keys, PubKey, WalletKeys};
+use transparent::{KeyPoolEntry, Keys, PubKey, ScriptId, WalletKeys, WatchScript};
 
 #[derive(Debug)]
 pub struct ZcashdWallet {
@@ -42,6 +42,7 @@ pub struct ZcashdWallet {
     bestblock_nomerkle: Option<BlockLocator>,
     bestblock: BlockLocator,
     client_version: ClientVersion,
+    cscripts: HashMap<ScriptId, Script>,
     default_key: PubKey,
     key_pool: HashMap<i64, KeyPoolEntry>,
     keys: Keys,
@@ -59,6 +60,7 @@ pub struct ZcashdWallet {
     wallet_keys: Option<WalletKeys>,
     transactions: HashMap<TxId, WalletTx>,
     unified_accounts: UnifiedAccounts,
+    watch_scripts: Vec<WatchScript>,
     witnesscachesize: i64,
 }
 
@@ -70,6 +72,7 @@ impl ZcashdWallet {
         bestblock_nomerkle: Option<BlockLocator>,
         bestblock: BlockLocator,
         client_version: ClientVersion,
+        cscripts: HashMap<ScriptId, Script>,
         default_key: PubKey,
         key_pool: HashMap<i64, KeyPoolEntry>,
         keys: Keys,
@@ -87,6 +90,7 @@ impl ZcashdWallet {
         wallet_keys: Option<WalletKeys>,
         transactions: HashMap<TxId, WalletTx>,
         unified_accounts: UnifiedAccounts,
+        watch_scripts: Vec<WatchScript>,
         witnesscachesize: i64,
     ) -> Self {
         ZcashdWallet {
@@ -95,6 +99,7 @@ impl ZcashdWallet {
             bestblock_nomerkle,
             bestblock,
             client_version,
+            cscripts,
             default_key,
             key_pool,
             keys,
@@ -112,6 +117,7 @@ impl ZcashdWallet {
             wallet_keys,
             transactions,
             unified_accounts,
+            watch_scripts,
             witnesscachesize,
         }
     }
@@ -133,6 +139,13 @@ impl ZcashdWallet {
 
     pub fn client_version(&self) -> &ClientVersion {
         &self.client_version
+    }
+
+    /// Redeem scripts imported via the `importaddress` RPC and stored under the
+    /// `cscript` BDB key, keyed by their 20-byte `CScriptID` (RIPEMD-160 of
+    /// SHA-256 of the script).
+    pub fn cscripts(&self) -> &HashMap<ScriptId, Script> {
+        &self.cscripts
     }
 
     pub fn default_key(&self) -> &PubKey {
@@ -203,6 +216,14 @@ impl ZcashdWallet {
 
     pub fn unified_accounts(&self) -> &UnifiedAccounts {
         &self.unified_accounts
+    }
+
+    /// Watch-only output scripts imported via the `importaddress` or
+    /// `importpubkey` RPCs and stored under the `watchs` BDB key. Each entry
+    /// carries the raw script alongside a classification of the standard
+    /// transparent patterns (P2PK / P2PKH / P2SH).
+    pub fn watch_scripts(&self) -> &[WatchScript] {
+        &self.watch_scripts
     }
 
     pub fn witnesscachesize(&self) -> i64 {

--- a/src/zcashd_wallet/transparent/mod.rs
+++ b/src/zcashd_wallet/transparent/mod.rs
@@ -9,3 +9,4 @@ mod_use!(key_pool);
 mod_use!(script_id);
 mod_use!(out_point);
 mod_use!(wallet_key);
+mod_use!(watch_script);

--- a/src/zcashd_wallet/transparent/priv_key.rs
+++ b/src/zcashd_wallet/transparent/priv_key.rs
@@ -26,6 +26,34 @@ impl PrivKey {
     pub fn hash(&self) -> u256 {
         self.hash
     }
+
+    /// Extracts the 32-byte secp256k1 scalar from the SEC1 `EC PRIVATE KEY`
+    /// DER blob stored by `zcashd`.
+    ///
+    /// Both the 214-byte (compressed pubkey) and 279-byte (uncompressed pubkey)
+    /// encodings carry an `INTEGER 1, OCTET STRING(32) <scalar>` prologue
+    /// inside the outer SEQUENCE. This locates that prologue by its byte
+    /// pattern (`02 01 01 04 20`) rather than by hardcoded offset, which keeps
+    /// the extractor robust to the differing SEQUENCE length encodings.
+    pub fn secp256k1_scalar(&self) -> Result<[u8; 32]> {
+        const MARKER: &[u8] = &[0x02, 0x01, 0x01, 0x04, 0x20];
+        let bytes = self.as_slice();
+        let start = bytes
+            .windows(MARKER.len())
+            .position(|w| w == MARKER)
+            .map(|i| i + MARKER.len())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "PrivKey does not contain expected SEC1 EC private key prologue"
+                )
+            })?;
+        if start + 32 > bytes.len() {
+            bail!("PrivKey too short to contain a 32-byte secp256k1 scalar");
+        }
+        let mut scalar = [0u8; 32];
+        scalar.copy_from_slice(&bytes[start..start + 32]);
+        Ok(scalar)
+    }
 }
 
 impl std::fmt::Debug for PrivKey {
@@ -55,5 +83,56 @@ impl Parse for PrivKey {
         let data = parse!(p, data = length, "PrivKey")?;
         let hash = parse!(p, "PrivKey hash")?;
         Ok(Self { data, hash })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zewif::Data;
+
+    fn make_compressed_blob(scalar: [u8; 32]) -> Data {
+        // 30 81 D3 (SEQ 211) + 02 01 01 (INTEGER 1) + 04 20 <scalar> + filler to 214 bytes
+        let mut blob = vec![0x30, 0x81, 0xD3, 0x02, 0x01, 0x01, 0x04, 0x20];
+        blob.extend_from_slice(&scalar);
+        blob.resize(214, 0xAA);
+        Data::from_slice(&blob)
+    }
+
+    fn make_uncompressed_blob(scalar: [u8; 32]) -> Data {
+        // 30 82 01 13 (SEQ 275) + 02 01 01 (INTEGER 1) + 04 20 <scalar> + filler to 279 bytes
+        let mut blob = vec![0x30, 0x82, 0x01, 0x13, 0x02, 0x01, 0x01, 0x04, 0x20];
+        blob.extend_from_slice(&scalar);
+        blob.resize(279, 0xBB);
+        Data::from_slice(&blob)
+    }
+
+    #[test]
+    fn extracts_scalar_from_compressed_blob() {
+        let scalar = [0x42u8; 32];
+        let pk = PrivKey {
+            data: make_compressed_blob(scalar),
+            hash: u256::default(),
+        };
+        assert_eq!(pk.secp256k1_scalar().unwrap(), scalar);
+    }
+
+    #[test]
+    fn extracts_scalar_from_uncompressed_blob() {
+        let scalar = [0x99u8; 32];
+        let pk = PrivKey {
+            data: make_uncompressed_blob(scalar),
+            hash: u256::default(),
+        };
+        assert_eq!(pk.secp256k1_scalar().unwrap(), scalar);
+    }
+
+    #[test]
+    fn rejects_blob_without_marker() {
+        let pk = PrivKey {
+            data: Data::from_slice(&vec![0u8; 214]),
+            hash: u256::default(),
+        };
+        assert!(pk.secp256k1_scalar().is_err());
     }
 }

--- a/src/zcashd_wallet/transparent/pub_key.rs
+++ b/src/zcashd_wallet/transparent/pub_key.rs
@@ -1,8 +1,14 @@
 use anyhow::{Context, Result, bail};
+use ripemd::{Digest as _, Ripemd160};
+use sha2::Sha256;
 
 use zewif::Data;
 
-use crate::{parse, parser::prelude::*, zcashd_wallet::CompactSize};
+use crate::{
+    parse,
+    parser::prelude::*,
+    zcashd_wallet::{CompactSize, transparent::KeyId, u160},
+};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PubKey(Data);
@@ -17,6 +23,17 @@ impl PubKey {
 
     pub fn is_compressed(&self) -> bool {
         self.0.as_slice().len() == Self::COMPRESSED_PUBLIC_KEY_SIZE
+    }
+
+    /// Computes the `KeyId` (HASH160 of the public key bytes) for this public
+    /// key, which is the 20-byte identifier embedded in the corresponding
+    /// transparent P2PKH address.
+    pub fn key_id(&self) -> KeyId {
+        let sha = Sha256::digest(self.as_slice());
+        let hash = Ripemd160::digest(sha);
+        let h160 = u160::from_slice(hash.as_slice())
+            .expect("RIPEMD-160 output is exactly 20 bytes");
+        KeyId::from(h160)
     }
 }
 

--- a/src/zcashd_wallet/transparent/watch_script.rs
+++ b/src/zcashd_wallet/transparent/watch_script.rs
@@ -1,0 +1,190 @@
+use anyhow::Result;
+use zewif::{Network, Script};
+
+use crate::{parse, parser::prelude::*, zcashd_wallet::u160};
+
+use super::{KeyId, PubKey, ScriptId};
+
+/// Opcodes used by standard Zcash transparent output scripts.
+const OP_DUP: u8 = 0x76;
+const OP_EQUAL: u8 = 0x87;
+const OP_EQUALVERIFY: u8 = 0x88;
+const OP_HASH160: u8 = 0xa9;
+const OP_CHECKSIG: u8 = 0xac;
+const PUSHBYTES_20: u8 = 0x14;
+const PUSHBYTES_33: u8 = 0x21;
+const PUSHBYTES_65: u8 = 0x41;
+
+/// Classification of a watch-only `CScript` imported via `importaddress` or
+/// `importpubkey`.
+///
+/// Consumers should match on this enum instead of re-inspecting opcodes; the
+/// `Other` variant carries the raw script for any non-standard case.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum WatchScriptKind {
+    /// `<pubkey> OP_CHECKSIG`
+    P2PK(PubKey),
+    /// `OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG`
+    P2PKH(KeyId),
+    /// `OP_HASH160 <20-byte hash> OP_EQUAL`
+    P2SH(ScriptId),
+    /// A script that does not match any of the standard patterns above.
+    Other,
+}
+
+impl WatchScriptKind {
+    /// Attempts to classify the given script bytes into a standard pattern.
+    pub fn classify(script: &[u8]) -> Self {
+        // P2PKH: 0x76 0xa9 0x14 <20 bytes> 0x88 0xac
+        if script.len() == 25
+            && script[0] == OP_DUP
+            && script[1] == OP_HASH160
+            && script[2] == PUSHBYTES_20
+            && script[23] == OP_EQUALVERIFY
+            && script[24] == OP_CHECKSIG
+        {
+            if let Ok(hash) = u160::from_slice(&script[3..23]) {
+                return WatchScriptKind::P2PKH(KeyId::from(hash));
+            }
+        }
+
+        // P2SH: 0xa9 0x14 <20 bytes> 0x87
+        if script.len() == 23
+            && script[0] == OP_HASH160
+            && script[1] == PUSHBYTES_20
+            && script[22] == OP_EQUAL
+        {
+            if let Ok(hash) = u160::from_slice(&script[2..22]) {
+                return WatchScriptKind::P2SH(ScriptId::from(hash));
+            }
+        }
+
+        // P2PK (compressed): 0x21 <33 bytes> 0xac
+        if script.len() == 35 && script[0] == PUSHBYTES_33 && script[34] == OP_CHECKSIG {
+            if let Ok(pubkey) = PubKey::parse_buf(&&script[..34], false) {
+                return WatchScriptKind::P2PK(pubkey);
+            }
+        }
+
+        // P2PK (uncompressed): 0x41 <65 bytes> 0xac
+        if script.len() == 67 && script[0] == PUSHBYTES_65 && script[66] == OP_CHECKSIG {
+            if let Ok(pubkey) = PubKey::parse_buf(&&script[..66], false) {
+                return WatchScriptKind::P2PK(pubkey);
+            }
+        }
+
+        WatchScriptKind::Other
+    }
+}
+
+/// A watch-only transparent output script recorded by `zcashd` under the
+/// `watchs` key.
+///
+/// The raw script is preserved verbatim; `kind` provides a ready-made
+/// classification into the standard `P2PK` / `P2PKH` / `P2SH` patterns.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WatchScript {
+    script: Script,
+    kind: WatchScriptKind,
+}
+
+impl WatchScript {
+    pub fn new(script: Script) -> Self {
+        let kind = WatchScriptKind::classify(script.as_ref());
+        Self { script, kind }
+    }
+
+    pub fn script(&self) -> &Script {
+        &self.script
+    }
+
+    pub fn kind(&self) -> &WatchScriptKind {
+        &self.kind
+    }
+
+    /// If this script corresponds to a standard transparent address pattern,
+    /// returns the encoded `t-addr` string for the given network.
+    pub fn to_address_string(&self, network: Network) -> Option<String> {
+        match &self.kind {
+            WatchScriptKind::P2PKH(key_id) => Some(key_id.to_string(network)),
+            WatchScriptKind::P2SH(script_id) => Some(script_id.to_string(network)),
+            WatchScriptKind::P2PK(_) | WatchScriptKind::Other => None,
+        }
+    }
+}
+
+impl Parse for WatchScript {
+    fn parse(p: &mut Parser) -> Result<Self> {
+        let script = parse!(p, Script, "watch-only script")?;
+        Ok(Self::new(script))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_p2pkh() {
+        let mut script = vec![OP_DUP, OP_HASH160, PUSHBYTES_20];
+        script.extend_from_slice(&[0xab; 20]);
+        script.extend_from_slice(&[OP_EQUALVERIFY, OP_CHECKSIG]);
+        assert!(matches!(
+            WatchScriptKind::classify(&script),
+            WatchScriptKind::P2PKH(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_p2sh() {
+        let mut script = vec![OP_HASH160, PUSHBYTES_20];
+        script.extend_from_slice(&[0xcd; 20]);
+        script.push(OP_EQUAL);
+        assert!(matches!(
+            WatchScriptKind::classify(&script),
+            WatchScriptKind::P2SH(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_p2pk_compressed() {
+        let mut script = vec![PUSHBYTES_33, 0x02];
+        script.extend_from_slice(&[0xee; 32]);
+        script.push(OP_CHECKSIG);
+        assert!(matches!(
+            WatchScriptKind::classify(&script),
+            WatchScriptKind::P2PK(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_p2pk_uncompressed() {
+        let mut script = vec![PUSHBYTES_65, 0x04];
+        script.extend_from_slice(&[0x11; 64]);
+        script.push(OP_CHECKSIG);
+        assert!(matches!(
+            WatchScriptKind::classify(&script),
+            WatchScriptKind::P2PK(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_other() {
+        assert!(matches!(
+            WatchScriptKind::classify(&[]),
+            WatchScriptKind::Other
+        ));
+        assert!(matches!(
+            WatchScriptKind::classify(&[0x00, 0x01, 0x02]),
+            WatchScriptKind::Other
+        ));
+        // Near-miss P2PKH with wrong last opcode.
+        let mut near_miss = vec![OP_DUP, OP_HASH160, PUSHBYTES_20];
+        near_miss.extend_from_slice(&[0x00; 20]);
+        near_miss.extend_from_slice(&[OP_EQUALVERIFY, 0x00]);
+        assert!(matches!(
+            WatchScriptKind::classify(&near_miss),
+            WatchScriptKind::Other
+        ));
+    }
+}


### PR DESCRIPTION
zcashd stores transparent addresses imported via the `importaddress` and `importpubkey` RPCs under the `watchs` and `cscript` keys, which were previously dropped on the floor. Without them, consumers (notably `zallet migrate-zcashd-wallet`, COR-1189) silently lost every imported transparent address during migration.

Parse both record types into `ZcashdWallet`, exposing `cscripts()` as a `ScriptID -> Script` map and `watch_scripts()` as a list of `WatchScript` values pre-classified into P2PK / P2PKH / P2SH / Other so consumers don't have to re-inspect opcodes. Carry the standard P2PKH and P2SH classifications through `src/migrate/` as watch-only transparent addresses on the zewif side.

Resolves: https://github.com/zcash/zewif-zcashd/issues/6
Resolves: [COR-1205](https://linear.app/zodl/issue/COR-1205/parse-watchs-and-cscript-bdb-records)