### PR TITLE
Derive a mnemonic seed for pre-v4.7.0 legacy accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,13 +105,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip0039"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2",
+ "rand",
+ "sha2 0.10.9",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
 name = "bip32"
 version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
 dependencies = [
  "bs58",
- "hmac",
+ "hmac 0.13.0-pre.4",
  "rand_core",
  "ripemd 0.2.0-pre.4",
  "secp256k1",
@@ -424,6 +444,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -721,6 +742,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
@@ -1003,6 +1033,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1056,16 @@ dependencies = [
  "rand",
  "static_assertions",
  "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "password-hash",
 ]
 
 [[package]]
@@ -1160,6 +1211,31 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ripemd"
@@ -1517,6 +1593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32 0.11.1",
+ "bip0039",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -1715,6 +1801,7 @@ dependencies = [
  "nonempty",
  "orchard",
  "rand_core",
+ "regex",
  "sapling-crypto",
  "secrecy",
  "subtle",
@@ -1899,6 +1986,7 @@ dependencies = [
  "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1",
+ "secrecy",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ uuid = "1.1"
 # `wallet.dat` encoded data, so these must be kept in sync.
 zcash_address = "0.12"
 zcash_encoding = "0.4"
-zcash_keys = { version = "0.14", features = ["transparent-inputs", "sapling", "orchard"] }
+zcash_keys = { version = "0.14", features = ["transparent-inputs", "sapling", "orchard", "zcashd-compat"] }
 zcash_primitives = "0.28"
 zcash_protocol = "0.9"
 zcash_transparent = { version = "0.8", features = ["transparent-inputs"] }
 secp256k1 = "0.29"
+secrecy = "0.8"
 zip32 = "0.2"
 orchard = "0.14"
 sapling = { package = "sapling-crypto", version = "0.7", features = ["temporary-zcashd"] }

--- a/src/migrate/accounts.rs
+++ b/src/migrate/accounts.rs
@@ -11,7 +11,7 @@ use zewif::{
 use crate::migrate::MigrateError;
 use crate::{
     ZcashdWallet,
-    migrate::secrets::mnemonic_seed_fingerprint,
+    migrate::secrets::{legacy_mnemonic_seed, mnemonic_seed_fingerprint},
     zcashd_wallet::UfvkFingerprint,
 };
 
@@ -94,18 +94,22 @@ pub(crate) fn build_accounts(
     // legacy Sapling, and Sprout addresses (zcashd account 0x7FFFFFFF).
     let mut legacy = Account::new(AccountViewingKey::TransparentAddressSet);
     legacy.set_name("Legacy");
-    // The mnemonic seed is the only seed from which zcashd ever derives keys
-    // at account index 0x7FFFFFFF: post-v4.7.0 `getnewaddress` transparent
-    // keys (m/44'/coin'/0x7FFFFFFF'/change/index) and post-v4.7.0
-    // `z_getnewaddress` Sapling keys (m/32'/coin'/0x7FFFFFFF'/idx'). The
-    // pre-mnemonic legacy seed only ever derived Sapling keys, at
-    // m/32'/coin'/account' (pre-v4.7.0), and pre-v4.7.0 transparent keys are
-    // plain system randomness. A wallet without a mnemonic therefore has no
-    // derivation root for this account: its keys are a bag of imported
-    // material whose secrets (including the legacy seed itself, from which
-    // pre-v4.7.0 Sapling keys can be re-derived) are individually present in
-    // the secret store.
-    match mnemonic_seed_fingerprint(wallet) {
+    // zcashd derives the keys of account index 0x7FFFFFFF from the mnemonic
+    // seed: post-v4.7.0 `getnewaddress` transparent keys
+    // (m/44'/coin'/0x7FFFFFFF'/change/index) and post-v4.7.0 `z_getnewaddress`
+    // Sapling keys (m/32'/coin'/0x7FFFFFFF'/idx'). A v4.7.0+ wallet records that
+    // mnemonic directly. A pre-mnemonic wallet records none, but if it carries a
+    // legacy HD seed then zcashd's own upgrade would re-derive the mnemonic from
+    // it; reproducing that (`legacy_mnemonic_seed`) lets the legacy account —
+    // and the imported transparent addresses attached to it — import as a
+    // seed-derived account. A wallet with neither a mnemonic nor a legacy seed
+    // (a bare set of imported addresses) has no derivation root, so its legacy
+    // account remains a bag of imported material.
+    let legacy_seed_fp = match mnemonic_seed_fingerprint(wallet) {
+        Some(fp) => Some(fp),
+        None => legacy_mnemonic_seed(wallet)?.map(|(_, fp)| fp),
+    };
+    match legacy_seed_fp {
         Some(seed_fp) => {
             legacy.set_key_source(KeySource::Derived(DerivedKeySource::new(
                 seed_fp,

--- a/src/migrate/secrets.rs
+++ b/src/migrate/secrets.rs
@@ -1,8 +1,8 @@
 
 use zewif::{
-    SecretStore, SeedEntry, SeedFingerprint, SeedMaterial, SproutKeyEntry,
-    TransparentKeyEntry, sapling::SaplingExtendedSpendingKey, sprout::SproutSpendingKey,
-    transparent::TransparentSpendingKey,
+    Bip39Mnemonic, LegacySeed, MnemonicLanguage, SecretStore, SeedEntry, SeedFingerprint,
+    SeedMaterial, SproutKeyEntry, TransparentKeyEntry, sapling::SaplingExtendedSpendingKey,
+    sprout::SproutSpendingKey, transparent::TransparentSpendingKey,
 };
 
 use crate::migrate::MigrateError;
@@ -11,16 +11,54 @@ use crate::{ZcashdWallet, migrate::addresses::sprout_address_string};
 /// The ZIP-32 seed fingerprint of the wallet's mnemonic seed, if a mnemonic is
 /// present. Taken from the mnemonic HD chain, where zcashd records it directly.
 pub(crate) fn mnemonic_seed_fingerprint(wallet: &ZcashdWallet) -> Option<SeedFingerprint> {
-    if wallet.bip39_mnemonic().mnemonic().is_empty() {
+    let mnemonic = wallet.bip39_mnemonic()?;
+    if mnemonic.mnemonic().is_empty() {
         return None;
     }
     let bytes: [u8; 32] = wallet
-        .mnemonic_hd_chain()
+        .mnemonic_hd_chain()?
         .seed_fp()
         .as_slice()
         .try_into()
         .ok()?;
     Some(crate::zcashd_wallet::encode_seed_fingerprint(&bytes))
+}
+
+/// The BIP-39 mnemonic and ZIP-32 seed fingerprint that zcashd derives from a
+/// pre-mnemonic (pre-v4.7.0) legacy HD seed when upgrading a wallet to mnemonic
+/// support.
+///
+/// zcashd re-expresses the 32-byte legacy seed as a BIP-39 mnemonic (see
+/// [`zcash_keys::keys::zcashd::derive_mnemonic`]) and thereafter derives the
+/// legacy account (index `0x7FFFFFFF`) from that mnemonic's 64-byte BIP-39
+/// seed. Reproducing that mnemonic lets a pre-v4.7.0 wallet's legacy account be
+/// imported as a seed-derived account rather than a bag of loose keys, so its
+/// imported transparent addresses are retained. The fingerprint is computed
+/// over the mnemonic's 64-byte seed, matching what the importer recomputes and
+/// what zcashd would have recorded on upgrade.
+pub(crate) fn derive_legacy_mnemonic_seed(
+    seed: &LegacySeed,
+) -> Result<(Bip39Mnemonic, SeedFingerprint), MigrateError> {
+    let legacy_seed = secrecy::SecretVec::new(seed.as_slice().to_vec());
+    let mnemonic = zcash_keys::keys::zcashd::derive_mnemonic(&legacy_seed)
+        .ok_or(MigrateError::InvalidLegacySeedLength)?;
+    let fp = zip32::fingerprint::SeedFingerprint::from_seed(&mnemonic.to_seed(""))
+        .ok_or(MigrateError::InvalidLegacySeedLength)?;
+    Ok((
+        Bip39Mnemonic::new(mnemonic.phrase(), Some(MnemonicLanguage::English)),
+        crate::zcashd_wallet::encode_seed_fingerprint(&fp.to_bytes()),
+    ))
+}
+
+/// The mnemonic seed derived from the wallet's legacy HD seed, if it has one.
+/// See [`derive_legacy_mnemonic_seed`].
+pub(crate) fn legacy_mnemonic_seed(
+    wallet: &ZcashdWallet,
+) -> Result<Option<(Bip39Mnemonic, SeedFingerprint)>, MigrateError> {
+    wallet
+        .legacy_hd_seed()
+        .map(derive_legacy_mnemonic_seed)
+        .transpose()
 }
 
 /// The ZIP-32 seed fingerprint of the wallet's pre-mnemonic legacy HD seed, if
@@ -47,13 +85,25 @@ pub(crate) fn legacy_seed_fingerprint(wallet: &ZcashdWallet) -> Result<Option<Se
 pub(crate) fn build_secret_store(wallet: &ZcashdWallet) -> Result<Option<SecretStore>, MigrateError> {
     let mut store = SecretStore::new();
 
-    // Seeds.
-    if let Some(fp) = mnemonic_seed_fingerprint(wallet) {
-        store.add_seed(SeedEntry::new(
-            fp,
-            SeedMaterial::Bip39Mnemonic(wallet.bip39_mnemonic().clone()),
-        ));
+    // Seeds. The mnemonic seed is recorded directly on v4.7.0+ wallets;
+    // for a pre-mnemonic wallet with a legacy HD seed it is re-derived from
+    // that seed exactly as zcashd's upgrade would, so the legacy account can
+    // be imported as a seed-derived account.
+    match (mnemonic_seed_fingerprint(wallet), wallet.bip39_mnemonic()) {
+        (Some(fp), Some(mnemonic)) => {
+            store.add_seed(SeedEntry::new(
+                fp,
+                SeedMaterial::Bip39Mnemonic(mnemonic.clone()),
+            ));
+        }
+        _ => {
+            if let Some((mnemonic, fp)) = legacy_mnemonic_seed(wallet)? {
+                store.add_seed(SeedEntry::new(fp, SeedMaterial::Bip39Mnemonic(mnemonic)));
+            }
+        }
     }
+    // The raw pre-mnemonic legacy seed is also retained, for recovery of
+    // legacy Sapling keys derived under the pre-v4.7.0 scheme.
     if let (Some(fp), Some(seed)) = (legacy_seed_fingerprint(wallet)?, wallet.legacy_hd_seed()) {
         store.add_seed(SeedEntry::new(
             fp,
@@ -196,4 +246,30 @@ fn transparent_key_entry(
         pubkey,
         TransparentSpendingKey::new(wif),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_mnemonic_matches_zcashd_derivation() {
+        // A 32-byte legacy seed is itself valid BIP-39 entropy (256 bits), so
+        // zcashd's `derive_mnemonic` reduces to the BIP-39 encoding of the seed
+        // bytes. All-zero entropy is the canonical BIP-39 test vector
+        // (23 * "abandon" + "art").
+        let seed = LegacySeed::from_vec(vec![0u8; 32]).expect("32 bytes");
+        let (mnemonic, fp) = derive_legacy_mnemonic_seed(&seed).expect("valid seed");
+
+        assert_eq!(
+            mnemonic.mnemonic(),
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+        );
+        assert!(mnemonic.language() == Some(&MnemonicLanguage::English));
+
+        // The fingerprint is canonical (Bech32m over the ZIP-32 fingerprint of
+        // the mnemonic's 64-byte BIP-39 seed) and deterministic.
+        assert!(fp.encoding().starts_with("zip32seedfp1"));
+        assert_eq!(fp, derive_legacy_mnemonic_seed(&seed).unwrap().1);
+    }
 }

--- a/src/zcashd_parser.rs
+++ b/src/zcashd_parser.rs
@@ -431,9 +431,13 @@ impl<'a> ZcashdParser<'a> {
         Ok(parse!(buf = value, PubKey, "defaultkey")?)
     }
 
-    fn parse_mnemonic_hd_chain(&self) -> Result<MnemonicHDChain, Error> {
+    fn parse_mnemonic_hd_chain(&self) -> Result<Option<MnemonicHDChain>, Error> {
+        // Absent in wallets predating zcashd's v4.7.0 mnemonic support.
+        if !self.dump.has_value_for_keyname("mnemonichdchain") {
+            return Ok(None);
+        }
         let value = self.value_for_keyname("mnemonichdchain")?;
-        Ok(parse!(buf = value, MnemonicHDChain, "mnemonichdchain")?)
+        Ok(Some(parse!(buf = value, MnemonicHDChain, "mnemonichdchain")?))
     }
 
     fn parse_send_recipients(&self) -> Result<HashMap<TxId, Vec<RecipientMapping>>, Error> {
@@ -540,7 +544,11 @@ impl<'a> ZcashdParser<'a> {
         })
     }
 
-    fn parse_mnemonic_phrase(&self) -> Result<Bip39Mnemonic, Error> {
+    fn parse_mnemonic_phrase(&self) -> Result<Option<Bip39Mnemonic>, Error> {
+        // Absent in wallets predating zcashd's v4.7.0 mnemonic support.
+        if !self.dump.has_keys_for_keyname("mnemonicphrase") {
+            return Ok(None);
+        }
         let (key, value) = self
             .dump
             .record_for_keyname("mnemonicphrase")?;
@@ -550,7 +558,7 @@ impl<'a> ZcashdParser<'a> {
         let _fingerprint = parse!(buf = &key.data, SeedFingerprint, "seed fingerprint")?;
         let bip39_mnemonic = parse!(buf = &value, Bip39Mnemonic, "mnemonic phrase")?;
         self.mark_key_parsed(&key);
-        Ok(bip39_mnemonic)
+        Ok(Some(bip39_mnemonic))
     }
 
     fn parse_address_names(&self) -> Result<HashMap<Address, String>, Error> {

--- a/src/zcashd_wallet.rs
+++ b/src/zcashd_wallet.rs
@@ -57,8 +57,8 @@ pub struct ZcashdWallet {
     keys: Keys,
     min_version: ClientVersion,
     legacy_hd_seed: Option<LegacySeed>,
-    mnemonic_hd_chain: MnemonicHDChain,
-    bip39_mnemonic: Bip39Mnemonic,
+    mnemonic_hd_chain: Option<MnemonicHDChain>,
+    bip39_mnemonic: Option<Bip39Mnemonic>,
     network_info: NetworkInfo,
     orchard_note_commitment_tree: OrchardNoteCommitmentTree,
     orderposnext: Option<i64>,
@@ -89,8 +89,8 @@ impl ZcashdWallet {
         keys: Keys,
         min_version: ClientVersion,
         legacy_hd_seed: Option<LegacySeed>,
-        mnemonic_hd_chain: MnemonicHDChain,
-        bip39_mnemonic: Bip39Mnemonic,
+        mnemonic_hd_chain: Option<MnemonicHDChain>,
+        bip39_mnemonic: Option<Bip39Mnemonic>,
         network_info: NetworkInfo,
         orchard_note_commitment_tree: OrchardNoteCommitmentTree,
         orderposnext: Option<i64>,
@@ -184,12 +184,16 @@ impl ZcashdWallet {
         self.legacy_hd_seed.as_ref()
     }
 
-    pub fn mnemonic_hd_chain(&self) -> &MnemonicHDChain {
-        &self.mnemonic_hd_chain
+    /// The mnemonic HD chain metadata, present only for wallets created or
+    /// upgraded by zcashd v4.7.0 or later.
+    pub fn mnemonic_hd_chain(&self) -> Option<&MnemonicHDChain> {
+        self.mnemonic_hd_chain.as_ref()
     }
 
-    pub fn bip39_mnemonic(&self) -> &Bip39Mnemonic {
-        &self.bip39_mnemonic
+    /// The wallet's BIP-39 mnemonic, present only for wallets created or
+    /// upgraded by zcashd v4.7.0 or later.
+    pub fn bip39_mnemonic(&self) -> Option<&Bip39Mnemonic> {
+        self.bip39_mnemonic.as_ref()
     }
 
     pub fn network_info(&self) -> &NetworkInfo {


### PR DESCRIPTION
## Summary

A wallet created before zcashd v4.7.0 has no mnemonic seed. Previously such a
wallet could not be parsed at all — the `mnemonicphrase` and `mnemonichdchain`
records were mandatory — and even once parsed, its legacy account (the pool of
pre-mnemonic / imported keys at index `0x7FFFFFFF`) was emitted with
`KeySource::Imported`, so a ZeWIF importer had no derivation root for it and
dropped its imported transparent addresses.

This PR:

- Makes the `mnemonicphrase` / `mnemonichdchain` records optional
  (`bip39_mnemonic` and `mnemonic_hd_chain` become `Option`), so pre-v4.7.0
  wallets parse.
- For a pre-mnemonic wallet that carries a legacy HD seed, re-derives the BIP-39
  mnemonic that zcashd itself would produce from that seed on upgrade (via
  `zcash_keys::keys::zcashd::derive_mnemonic`) and keys the synthesized legacy
  account to it (`DerivedKeySource` at index `0x7FFFFFFF`). The mnemonic is
  emitted as the account's seed material, with its fingerprint computed over the
  mnemonic's 64-byte BIP-39 seed — matching what an importer recomputes and what
  a real post-upgrade zcashd wallet records.

The legacy account keeps its `AccountViewingKey::TransparentAddressSet`, and all
transparent addresses already attach to it, so an importer that can assign the
account a unified incoming viewing key (which it now can, from the seed) retains
the imported transparent address set instead of skipping the account.

A wallet with neither a mnemonic nor a legacy HD seed (a bare set of imported
addresses) still has no derivation root and remains `KeySource::Imported`.

## Correctness

The seed entry (`build_secret_store`) and the account's `DerivedKeySource`
(`build_accounts`) take their fingerprint from the same `legacy_mnemonic_seed`
helper, so they are identical by construction. The emitted shape — a
`TransparentAddressSet` account + `DerivedKeySource` at `0x7FFFFFFF` + a matching
`Bip39Mnemonic` seed entry — is exactly what the librustzcash ZeWIF importer
already consumes. A unit test confirms the all-zero legacy seed reproduces the
canonical BIP-39 vector (`abandon … art`).

## Dependencies

Enables `zcash_keys`'s `zcashd-compat` feature (for `derive_mnemonic`) and adds
`secrecy` (already resolved in the tree) for the `SecretVec` that function takes.
This does not affect `wallet.dat` deserialization fidelity.

Part of zcash/librustzcash#2582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
