### PR TITLE
Support caller-supplied regtest activation schedules on export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ zcash_address = "0.12"
 zcash_encoding = "0.4"
 zcash_keys = { version = "0.14", features = ["transparent-inputs", "sapling", "orchard", "zcashd-compat"] }
 zcash_primitives = "0.28"
-zcash_protocol = "0.9"
+zcash_protocol = { version = "0.9", features = ["local-consensus"] }
 zcash_transparent = { version = "0.8", features = ["transparent-inputs"] }
 secp256k1 = "0.29"
 secrecy = "0.8"
@@ -35,6 +35,11 @@ incrementalmerkletree = "0.8"
 bridgetree = "0.7"
 bs58 = { version = "0.5.1", features = ["check"] }
 bech32 = "0.12"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(zcash_unstable, values("nu7"))',
+] }
 
 [patch.crates-io]
 zewif = { git = "https://github.com/zcash/zewif.git", branch = "main" }

--- a/examples/read_wallet.rs
+++ b/examples/read_wallet.rs
@@ -56,7 +56,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let export_height = BlockHeight::from_u32(2_400_000);
 
     println!("\n=== ZeWIF migration ===");
-    let zewif = migrate_to_zewif(&wallet, export_height)?;
+    // A regtest wallet would pass `Some(RegtestActivations::Local(..))` here to
+    // record its activation schedule; mainnet/testnet exports pass `None`.
+    let zewif = migrate_to_zewif(&wallet, export_height, None)?;
     for w in zewif.wallets() {
         println!("accounts:      {}", w.accounts().len());
         println!("address book:  {}", w.address_book().len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,5 @@ mod_use!(zcashd_parser);
 pub mod migrate;
 pub mod parser;
 pub mod zcashd_wallet;
-pub use migrate::migrate_to_zewif;
+pub use migrate::{RegtestActivations, migrate_to_zewif};
 pub use zcashd_wallet::ZcashdWallet;

--- a/src/migrate/migrate_to_zewif.rs
+++ b/src/migrate/migrate_to_zewif.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
 
-use zewif::{BlockHash, BlockHeight, Secrets, Zewif, ZewifWallet};
+use zcash_protocol::consensus::BranchId;
+use zcash_protocol::local_consensus::LocalNetwork;
+use zewif::{BlockHash, BlockHeight, Network, RegtestParams, Secrets, Zewif, ZewifWallet};
 
 use crate::migrate::MigrateError;
 use crate::ZcashdWallet;
@@ -12,14 +15,79 @@ use super::{
     transactions::collect_tx_heights,
 };
 
+/// How to determine a regtest network's network-upgrade activation schedule
+/// when exporting a regtest wallet.
+///
+/// A zcashd `wallet.dat` does not record the regtest activation schedule (it
+/// comes from node configuration, e.g. `-nuparams`), so the caller must supply
+/// it for the exported document to describe the chain the wallet was recorded
+/// against. This is ignored when exporting a mainnet or testnet wallet, whose
+/// activation schedules are fixed by the protocol.
+#[non_exhaustive]
+pub enum RegtestActivations {
+    /// The local consensus parameters the wallet was recorded against, supplied
+    /// directly by the caller. This is the mode for an offline export, with no
+    /// running node to consult.
+    Local(LocalNetwork),
+}
+
+/// Builds the ZeWIF regtest activation schedule — a map from consensus branch ID
+/// to activation height — from a set of local consensus parameters. Upgrades
+/// that the parameters leave unactivated are omitted.
+fn regtest_params_from_local(local: &LocalNetwork) -> RegtestParams {
+    let mut activations = BTreeMap::new();
+    for (height, branch_id) in [
+        (local.overwinter, BranchId::Overwinter),
+        (local.sapling, BranchId::Sapling),
+        (local.blossom, BranchId::Blossom),
+        (local.heartwood, BranchId::Heartwood),
+        (local.canopy, BranchId::Canopy),
+        (local.nu5, BranchId::Nu5),
+        (local.nu6, BranchId::Nu6),
+        (local.nu6_1, BranchId::Nu6_1),
+        (local.nu6_2, BranchId::Nu6_2),
+    ] {
+        if let Some(height) = height {
+            activations.insert(u32::from(branch_id), u32::from(height));
+        }
+    }
+    #[cfg(zcash_unstable = "nu7")]
+    if let Some(height) = local.nu7 {
+        activations.insert(u32::from(BranchId::Nu7), u32::from(height));
+    }
+    RegtestParams::new(activations)
+}
+
+/// The network to record in the exported document.
+///
+/// For a regtest wallet with a caller-supplied activation schedule, that
+/// schedule replaces the empty default the parser produces; in every other case
+/// (a regtest wallet with no supplied schedule, or a mainnet/testnet wallet) the
+/// wallet's own network is used unchanged.
+fn export_network(network: &Network, regtest_activations: Option<&RegtestActivations>) -> Network {
+    match (network, regtest_activations) {
+        (Network::Regtest(_), Some(RegtestActivations::Local(local))) => {
+            Network::Regtest(regtest_params_from_local(local))
+        }
+        _ => network.clone(),
+    }
+}
+
 /// Migrate a parsed zcashd wallet into a ZeWIF document.
 ///
 /// `export_height` is the chain tip height at export time, supplied by the
 /// caller (zcashd's `wallet.dat` records only a block-hash locator, not a
 /// numeric height). The export block hash is taken from that locator's tip.
+///
+/// `regtest_activations` supplies the network-upgrade activation schedule when
+/// exporting a regtest wallet, which the `wallet.dat` does not record; see
+/// [`RegtestActivations`]. Pass `None` to export a regtest wallet without a
+/// schedule (an importer then trusts its own regtest parameters), or when
+/// exporting a mainnet or testnet wallet.
 pub fn migrate_to_zewif(
     wallet: &ZcashdWallet,
     export_height: BlockHeight,
+    regtest_activations: Option<RegtestActivations>,
 ) -> Result<Zewif, MigrateError> {
     let params = wallet.network_info().to_address_encoding_network();
 
@@ -36,7 +104,10 @@ pub fn migrate_to_zewif(
     set_account_birthdays(wallet, &mut accounts);
 
     // Assemble the wallet.
-    let mut zewif_wallet = ZewifWallet::new(wallet.network().clone());
+    let mut zewif_wallet = ZewifWallet::new(export_network(
+        wallet.network(),
+        regtest_activations.as_ref(),
+    ));
     for account in accounts.accounts {
         zewif_wallet.add_account(account);
     }
@@ -84,5 +155,85 @@ fn set_account_birthdays(wallet: &ZcashdWallet, accounts: &mut WalletAccounts) {
         if let Some(height) = birthday {
             account.set_birthday_height(BlockHeight::from_u32(height));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::consensus::BlockHeight as ConsensusBlockHeight;
+
+    use super::*;
+
+    /// A regtest network activating every upgrade at a distinct height, so the
+    /// branch-ID-to-height mapping can be checked unambiguously.
+    fn distinct_local_network() -> LocalNetwork {
+        LocalNetwork {
+            overwinter: Some(ConsensusBlockHeight::from_u32(1)),
+            sapling: Some(ConsensusBlockHeight::from_u32(2)),
+            blossom: Some(ConsensusBlockHeight::from_u32(3)),
+            heartwood: Some(ConsensusBlockHeight::from_u32(4)),
+            canopy: Some(ConsensusBlockHeight::from_u32(5)),
+            nu5: Some(ConsensusBlockHeight::from_u32(6)),
+            nu6: Some(ConsensusBlockHeight::from_u32(7)),
+            nu6_1: Some(ConsensusBlockHeight::from_u32(8)),
+            nu6_2: Some(ConsensusBlockHeight::from_u32(9)),
+            #[cfg(zcash_unstable = "nu7")]
+            nu7: Some(ConsensusBlockHeight::from_u32(10)),
+        }
+    }
+
+    #[test]
+    fn local_network_converts_to_branch_id_keyed_schedule() {
+        let params = regtest_params_from_local(&distinct_local_network());
+        assert_eq!(
+            params.activations().get(&u32::from(BranchId::Sapling)),
+            Some(&2)
+        );
+        assert_eq!(params.activations().get(&u32::from(BranchId::Nu5)), Some(&6));
+        assert_eq!(
+            params.activations().get(&u32::from(BranchId::Nu6_2)),
+            Some(&9)
+        );
+    }
+
+    #[test]
+    fn unactivated_upgrades_are_omitted() {
+        let mut local = distinct_local_network();
+        local.nu6_2 = None;
+        let params = regtest_params_from_local(&local);
+        assert!(
+            params
+                .activations()
+                .get(&u32::from(BranchId::Nu6_2))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn export_network_populates_regtest_schedule() {
+        let activations = RegtestActivations::Local(distinct_local_network());
+        let out = export_network(&Network::Regtest(RegtestParams::default()), Some(&activations));
+        match out {
+            Network::Regtest(params) => assert_eq!(
+                params.activations().get(&u32::from(BranchId::Sapling)),
+                Some(&2)
+            ),
+            other => panic!("expected a regtest network, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn export_network_regtest_without_activations_is_unchanged() {
+        let network = Network::Regtest(RegtestParams::default());
+        assert_eq!(export_network(&network, None), network);
+    }
+
+    #[test]
+    fn export_network_ignores_activations_for_mainnet() {
+        let activations = RegtestActivations::Local(distinct_local_network());
+        assert_eq!(
+            export_network(&Network::Mainnet, Some(&activations)),
+            Network::Mainnet
+        );
     }
 }


### PR DESCRIPTION
## Summary

A zcashd `wallet.dat` does not record the regtest network-upgrade activation
schedule (it comes from node configuration, e.g. `-nuparams`), so an exported
regtest document previously carried an empty schedule (`RegtestParams::default()`)
and an importer had nothing to verify against.

This adds a `regtest_activations` argument to `migrate_to_zewif` through which the
caller supplies the schedule:

- New `#[non_exhaustive] pub enum RegtestActivations` with a `Local(LocalNetwork)`
  variant — the offline mode, where the caller provides the same
  `zcash_protocol::LocalNetwork` parameters the wallet was recorded against (and
  that an importer initializes its wallet database with). `#[non_exhaustive]`
  leaves room for a future node-backed variant that queries a running node.
- For a regtest wallet with `Some(Local(..))`, the document's network records the
  activation schedule (consensus branch ID → activation height), derived from the
  `LocalNetwork`. With `None`, the schedule is left empty (an importer then trusts
  its own regtest parameters). Mainnet/testnet exports ignore the argument.

Only the network stored in the document changes; address encoding is untouched.

Because the same `LocalNetwork` drives both the export schedule and an importer's
wallet-database parameters, the two match by construction — see the importer side
in zcash/librustzcash#2587.

## Notes

The pinned `zcash_protocol 0.9` tops out at `Nu6_2`, so the mapping covers
Overwinter…Nu6_2 (plus `nu7` under the unstable cfg); it will pick up newer
upgrades when the crate bumps its `zcash_protocol` dependency.

## Tests

Unit tests for the `LocalNetwork` → `RegtestParams` conversion (including that
unactivated upgrades are omitted) and for the network-selection helper (regtest
populated, regtest-without-schedule unchanged, mainnet ignores the argument).

Part of zcash/librustzcash#2584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
