### PR TITLE
Bump dependency stack to zcash_protocol 0.10 cohort and release rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.4] - 2026-08-13
+
 ### Added
 - Support for parsing pre-Sapling (HD-seedless) wallets, e.g. those created by
   zcashd 1.x. Records that such wallets lack — the address book (`name` /
@@ -33,6 +35,13 @@ and this library adheres to Rust's notion of
   missing-records policy at the record-lookup layer.
 
 ### Changed
+- Bumped dependency stack to the `zcash_protocol 0.10` cohort:
+  `zcash_protocol` 0.9 → 0.10, `zcash_address` 0.12 → 0.13,
+  `zcash_keys` 0.14 → 0.16.1, `zcash_primitives` 0.28 → 0.30,
+  `zcash_transparent` 0.8 → 0.10, `orchard` 0.14 → 0.15. The wallet.dat
+  binary format is unaffected; these bumps align the crate with the current
+  librustzcash release cohort and eliminate the need for downstream
+  consumers to maintain a versioned `zcash_protocol` alias.
 - `ZcashdWallet::witnesscachesize` now returns `Option<i64>`, as the record is
   absent from wallets never touched by a witness-caching zcashd version.
 - A truncated `orchard_note_commitment_tree` record is now reported as a parse

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,9 +999,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -1794,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -1838,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -1868,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+checksum = "043686451284bcb72e40ffa18e2cdcea3108e8468e3d021062c0b32c4a060c98"
 dependencies = [
  "corez",
  "document-features",
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "aes",
  "bech32 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zewif-zcashd"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -31,16 +31,16 @@ blake2b_simd = "1"
 # 0.6.20` and should not be updated unless `zcashd` updates its dependency
 # versions. This crate exists expressly for deserialization of `zcashd`
 # `wallet.dat` encoded data, so these must be kept in sync.
-zcash_address = "0.12"
+zcash_address = "0.13"
 zcash_encoding = "0.4"
-zcash_keys = { version = "0.14", features = ["transparent-inputs", "sapling", "orchard", "zcashd-compat"] }
-zcash_primitives = "0.28"
-zcash_protocol = { version = "0.9", features = ["local-consensus"] }
-zcash_transparent = { version = "0.8", features = ["transparent-inputs"] }
+zcash_keys = { version = "0.16.1", features = ["transparent-inputs", "sapling", "orchard", "zcashd-compat"] }
+zcash_primitives = "0.30"
+zcash_protocol = { version = "0.10", features = ["local-consensus"] }
+zcash_transparent = { version = "0.10", features = ["transparent-inputs"] }
 secp256k1 = "0.29"
 secrecy = "0.8"
 zip32 = "0.2"
-orchard = "0.14"
+orchard = "0.15"
 sapling = { package = "sapling-crypto", version = "0.7", features = ["temporary-zcashd"] }
 incrementalmerkletree = "0.8"
 bridgetree = "0.7"

--- a/src/migrate/migrate_to_zewif.rs
+++ b/src/migrate/migrate_to_zewif.rs
@@ -230,8 +230,9 @@ mod tests {
             nu6: Some(ConsensusBlockHeight::from_u32(7)),
             nu6_1: Some(ConsensusBlockHeight::from_u32(8)),
             nu6_2: Some(ConsensusBlockHeight::from_u32(9)),
+            nu6_3: Some(ConsensusBlockHeight::from_u32(10)),
             #[cfg(zcash_unstable = "nu7")]
-            nu7: Some(ConsensusBlockHeight::from_u32(10)),
+            nu7: Some(ConsensusBlockHeight::from_u32(11)),
         }
     }
 

--- a/tests/pre_sapling_wallet.rs
+++ b/tests/pre_sapling_wallet.rs
@@ -107,6 +107,7 @@ fn migrates_to_a_single_imported_legacy_account() {
         nu6: None,
         nu6_1: None,
         nu6_2: None,
+        nu6_3: None,
         #[cfg(zcash_unstable = "nu7")]
         nu7: None,
     });


### PR DESCRIPTION
Bumps the dependency stack from the `zcash_protocol 0.9` cohort to `0.10`:

- `zcash_protocol` 0.9 → 0.10
- `zcash_address` 0.12 → 0.13
- `zcash_keys` 0.14 → 0.16.1
- `zcash_primitives` 0.28 → 0.30
- `zcash_transparent` 0.8 → 0.10
- `orchard` 0.14 → 0.15

The `wallet.dat` binary format is unaffected by these bumps. The only code change required is adding the `nu6_3` field to `LocalNetwork` initializers in tests, as `zcash_protocol 0.10` added that field (0.9 lacked it).

## Motivation

This aligns `zewif-zcashd` with the current librustzcash release cohort. Downstream consumer `zallet` (zcash/zallet#741) currently maintains a versioned `zcash_protocol_0_9` alias to bridge the version skew between `zewif-zcashd` (on 0.9) and its own `zcash_protocol 0.10` dep. This bump eliminates the need for that alias.

This release also ships the pre-Sapling parser support (#23), the regtest HRP encoding fix, and parser hardening changes that were in the Unreleased section.

## Verification

- `cargo check` — clean
- `cargo test` — 89 tests pass (52 + 8 + 3 + 25 doctests + 1 ignored)
- `RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test` — all pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo publish --dry-run` — package verified, ready to upload

After merge, tag `0.1.0-rc.4` and `cargo publish`.

Co-Authored-By: Claude <noreply@anthropic.com>